### PR TITLE
Always create foreign keys from 1, not random

### DIFF
--- a/db/generators.js
+++ b/db/generators.js
@@ -3,7 +3,7 @@ const broisms = require('./broisms.js');
 const names = require('./names.js');
 
 const make_numbers = function* (k = 100) {
-  let n = Math.random() * k >> 0;
+  let n = 0;
   while (true) {
     n %= k;
     yield ++n;


### PR DESCRIPTION
Couldn't add foreign key relationship because not all user_ids in reviews had a corresponding id in users